### PR TITLE
fix PHP undefined constant warning

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -26,14 +26,14 @@ class admin_plugin_toucher extends DokuWiki_Admin_Plugin {
     }
 
     function touchFiles() {
-        touch(DOKU_CONF."local.php"); // this is the core of this plugin
+        touch(DOKU_CONF.'local.php'); // this is the core of this plugin
     }
  
     public function handle() {
         global $INFO;
 
         if ($this->getConf('admin_only')) {
-            if (!$INFO[isadmin]) {
+            if (!$INFO['isadmin']) {
                 msg('Plugin toucher failed: you must be admin to touch configuration',-1);
                 return false;
             }

--- a/admin.php
+++ b/admin.php
@@ -11,6 +11,12 @@ if (!defined('DOKU_INC')) die();
 
 class admin_plugin_toucher extends DokuWiki_Admin_Plugin
 {
+    public function getMenuIcon()
+    {
+        // use same icon of configration manager
+        return DOKU_PLUGIN.'config/admin.svg';
+    }
+
     public function getMenuSort()
     {
         return 13;

--- a/admin.php
+++ b/admin.php
@@ -9,44 +9,42 @@
 // must be run within Dokuwiki
 if (!defined('DOKU_INC')) die();
 
-if (!defined('DOKU_LF')) define('DOKU_LF', "\n");
-if (!defined('DOKU_TAB')) define('DOKU_TAB', "\t");
-if (!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
-
-require_once DOKU_PLUGIN.'admin.php';
-
-class admin_plugin_toucher extends DokuWiki_Admin_Plugin {
-
-    public function getMenuSort() {
+class admin_plugin_toucher extends DokuWiki_Admin_Plugin
+{
+    public function getMenuSort()
+    {
         return 13;
     }
 
-    public function forAdminOnly() {
+    public function forAdminOnly()
+    {
         return $this->getConf('admin_only');
     }
 
-    function touchFiles() {
+    protected function touchFiles()
+    {
         touch(DOKU_CONF.'local.php'); // this is the core of this plugin
     }
  
-    public function handle() {
+    public function handle()
+    {
         global $INFO;
 
         if ($this->getConf('admin_only')) {
             if (!$INFO['isadmin']) {
-                msg('Plugin toucher failed: you must be admin to touch configuration',-1);
+                msg('Plugin toucher failed: you must be admin to touch configuration', -1);
                 return false;
             }
         }
         $this->touchFiles();
-        msg('Plugin toucher touched configuration files',1);
+        msg('Plugin toucher touched configuration files', 1);
         return true;
     }
 
-    public function html() {
+    public function html()
+    {
         ptln('<h1>' . $this->getLang('menu') . '</h1>');
         ptln('<p>Configuration files have been just touched.</p>');
     }
 }
 
-// vim:ts=4:sw=4:et:


### PR DESCRIPTION
PHP Warning:  Use of undefined constant isadmin - assumed 'isadmin'
(this will throw an Error in a future version of PHP)