### PR TITLE
Error_log fix

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -33,7 +33,7 @@ class admin_plugin_toucher extends DokuWiki_Admin_Plugin {
         global $INFO;
 
         if ($this->getConf('admin_only')) {
-            if (!$INFO[isadmin]) {
+            if (!$INFO['isadmin']) {
                 msg('Plugin toucher failed: you must be admin to touch configuration',-1);
                 return false;
             }


### PR DESCRIPTION
[Tue Nov 19 14:09:20.519204 2019] [php7:warn] [pid 31737] [client <...>:48750] PHP Warning:  Use of undefined constant isadmin - assumed 'isadmin' (this will throw an Error in a future version of PHP) in /var/www/<...>/lib/plugins/toucher/admin.php on line 36, referer: <...>

Fixed.